### PR TITLE
Replace NamedTuples and Symbols with Enums

### DIFF
--- a/spec/neo4j/pack_stream/lexer_spec.cr
+++ b/spec/neo4j/pack_stream/lexer_spec.cr
@@ -3,10 +3,10 @@ require "../../../spec_helper"
 module Neo4j
   module PackStream
     describe Lexer do
-      it "lexes nil" do
+      it "lexes null" do
         lexer = Lexer.new("\xC0")
 
-        lexer.next_token.type.should eq :nil
+        lexer.next_token.type.should eq Token::Type::Null
       end
 
       it "lexes booleans" do
@@ -14,8 +14,8 @@ module Neo4j
         # values.
         lexer = Lexer.new("\xC2\xC3")
 
-        lexer.next_token.type.should eq :false
-        lexer.next_token.type.should eq :true
+        lexer.next_token.type.should eq Token::Type::False
+        lexer.next_token.type.should eq Token::Type::True
       end
 
       it "lexes strings" do
@@ -24,11 +24,11 @@ module Neo4j
         lexer = Lexer.new("\x85Jamie\xD0\x0DJamie Gaskins")
 
         lexer.next_token
-        lexer.token.type.should eq :STRING
+        lexer.token.type.should eq Token::Type::String
         lexer.token.string_value.should eq "Jamie"
 
         lexer.next_token
-        lexer.token.type.should eq :STRING
+        lexer.token.type.should eq Token::Type::String
         lexer.token.string_value.should eq "Jamie Gaskins"
       end
 
@@ -36,7 +36,7 @@ module Neo4j
         lexer = Lexer.new("\xC1\x01\x23\x45\x67\x89\xAB\xCD\xEF")
 
         lexer.next_token
-        lexer.token.type.should eq :FLOAT
+        lexer.token.type.should eq Token::Type::Float
         # The bytes 0123456789ABCDEF as a big-endian IEEE754 float results in a
         # very tiny positive number.
         lexer.token.float_value.should eq 3.512700564088504e-303
@@ -62,7 +62,7 @@ module Neo4j
         lexer = Lexer.new("\x90\x91")
 
         lexer.next_token
-        lexer.token.type.should eq :ARRAY
+        lexer.token.type.should eq Token::Type::Array
         lexer.token.size.should eq 0
 
         lexer.next_token
@@ -70,29 +70,29 @@ module Neo4j
 
         lexer = Lexer.new("\xD4\x10")
         lexer.next_token
-        lexer.token.type.should eq :ARRAY
+        lexer.token.type.should eq Token::Type::Array
         lexer.token.size.should eq 0x10
       end
 
       it "lexes hashes" do
         lexer = Lexer.new("\xAD").tap(&.next_token)
 
-        lexer.token.type.should eq :HASH
+        lexer.token.type.should eq Token::Type::Hash
         lexer.token.size.should eq 0x0D
 
         lexer = Lexer.new("\xD8\x80").tap(&.next_token)
-        lexer.token.type.should eq :HASH
+        lexer.token.type.should eq Token::Type::Hash
         lexer.token.size.should eq 0x80
       end
 
       it "lexes structures" do
         lexer = Lexer.new("\xB1").tap(&.next_token)
 
-        lexer.token.type.should eq :STRUCTURE
+        lexer.token.type.should eq Token::Type::Structure
         lexer.token.size.should eq 1
 
         lexer = Lexer.new("\xDC\x80").tap(&.next_token)
-        lexer.token.type.should eq :STRUCTURE
+        lexer.token.type.should eq Token::Type::Structure
         lexer.token.size.should eq 0x80
       end
     end

--- a/src/neo4j/bolt/connection.cr
+++ b/src/neo4j/bolt/connection.cr
@@ -16,13 +16,13 @@ module Neo4j
         0, 0, 0, 0,
         0, 0, 0, 0,
       ])
-      COMMANDS = {
-        init: 0x01,
-        run: 0x10,
-        pull_all: 0x3F,
-        ack_failure: 0x0E,
-        reset: 0x0F,
-      }
+      enum Commands
+        Init       = 0x01
+        Run        = 0x10
+        PullAll    = 0x3F
+        AckFailure = 0x0E
+        Reset      = 0x0F
+      end
 
       @connection : (TCPSocket | OpenSSL::SSL::Socket::Client)
 
@@ -106,7 +106,7 @@ module Neo4j
       def reset
         write_message do |msg|
           msg.write_structure_start 0
-          msg.write_byte COMMANDS[:reset]
+          msg.write_byte Commands::Reset
         end
         read_result
       end
@@ -114,7 +114,7 @@ module Neo4j
       private def init(username, password)
         write_message do |msg|
           msg.write_structure_start 1
-          msg.write_byte COMMANDS[:init]
+          msg.write_byte Commands::Init
           msg.write "Neo4j.cr/0.1.0"
           msg.write({
             "scheme" => "basic",
@@ -152,7 +152,7 @@ module Neo4j
       private def run(statement, parameters = {} of String => Type)
         write_message do |msg|
           msg.write_structure_start 2
-          msg.write_byte COMMANDS[:run]
+          msg.write_byte Commands::Run
           msg.write statement
           msg.write parameters
         end
@@ -174,7 +174,7 @@ module Neo4j
       private def pull_all
         write_message do |msg|
           msg.write_structure_start 0
-          msg.write_byte COMMANDS[:pull_all]
+          msg.write_byte Commands::PullAll
         end
 
         results = Array(Array(Type)).new
@@ -238,7 +238,7 @@ module Neo4j
       private def ack_failure
         write_message do |msg|
           msg.write_structure_start 0
-          msg.write_byte COMMANDS[:ack_failure]
+          msg.write_byte Commands::AckFailure
         end
         read_result
       end

--- a/src/neo4j/pack_stream/lexer.cr
+++ b/src/neo4j/pack_stream/lexer.cr
@@ -35,11 +35,11 @@ module Neo4j
 
         case current_byte
         when 0xC0
-          set_type_and_size(:nil, 0)
+          set_type_and_size(Token::Type::Null, 0)
         when 0xC2
-          set_type_and_size(:false, 0)
+          set_type_and_size(Token::Type::False, 0)
         when 0xC3
-          set_type_and_size(:true, 0)
+          set_type_and_size(Token::Type::True, 0)
         when 0x80..0x8F
           consume_string(current_byte - 0x80)
         when 0xD0
@@ -59,34 +59,34 @@ module Neo4j
         when 0xCB
           consume_int(read Int64)
         when 0x90..0x9F
-          set_type_and_size(:ARRAY, current_byte - 0x90)
+          set_type_and_size(Token::Type::Array, current_byte - 0x90)
         when 0xD4
-          set_type_and_size(:ARRAY, read UInt8)
+          set_type_and_size(Token::Type::Array, read UInt8)
         when 0xD5
-          set_type_and_size(:ARRAY, read UInt16)
+          set_type_and_size(Token::Type::Array, read UInt16)
         when 0xD6
-          set_type_and_size(:ARRAY, read UInt32)
+          set_type_and_size(Token::Type::Array, read UInt32)
         when 0xA0..0xAF
-          set_type_and_size(:HASH, current_byte - 0xA0)
+          set_type_and_size(Token::Type::Hash, current_byte - 0xA0)
         when 0xD8
-          set_type_and_size(:HASH, read UInt8)
+          set_type_and_size(Token::Type::Hash, read UInt8)
         when 0xD9
-          set_type_and_size(:HASH, read UInt16)
+          set_type_and_size(Token::Type::Hash, read UInt16)
         when 0xDA
-          set_type_and_size(:HASH, read UInt32)
+          set_type_and_size(Token::Type::Hash, read UInt32)
         when 0xB0..0xBF
-          set_type_and_size(:STRUCTURE, current_byte - 0xB0)
+          set_type_and_size(Token::Type::Structure, current_byte - 0xB0)
         when 0xDC
-          set_type_and_size(:STRUCTURE, read UInt8)
+          set_type_and_size(Token::Type::Structure, read UInt8)
         when 0xDD
-          set_type_and_size(:STRUCTURE, read UInt16)
+          set_type_and_size(Token::Type::Structure, read UInt16)
 
         # If we've gotten this far, I think it means it's a TINY_INT
         when 0x00..0x7F
-          @token.type = :INT
+          @token.type = Token::Type::Int
           @token.int_value = current_byte.to_i8
         when 0xF0..0xFF
-          @token.type = :INT
+          @token.type = Token::Type::Int
           @token.int_value = current_byte.to_i8
         else
           unexpected_byte!
@@ -107,7 +107,7 @@ module Neo4j
 
         unless byte
           @eof = true
-          @token.type = :EOF
+          @token.type = Token::Type::Eof
         end
 
         @current_byte = byte || 0.to_u8
@@ -120,18 +120,18 @@ module Neo4j
       end
 
       private def consume_int(value)
-        @token.type = :INT
+        @token.type = Token::Type::Int
         @token.int_value = value
       end
 
       private def consume_float(value)
-        @token.type = :FLOAT
+        @token.type = Token::Type::Float
         @token.float_value = value
       end
 
       private def consume_string(size)
         size = size.to_u32
-        @token.type = :STRING
+        @token.type = Token::Type::String
         @token.string_value = String.new(size) do |buffer|
           @io.read_fully(Slice.new(buffer, size))
           {size, 0}

--- a/src/neo4j/pack_stream/token.cr
+++ b/src/neo4j/pack_stream/token.cr
@@ -1,6 +1,19 @@
 module Neo4j
   module PackStream
     class Token
+      enum Type
+        Eof
+        Null
+        False
+        True
+        Array
+        Hash
+        Structure
+        Int
+        Float
+        String
+      end
+
       property type
 
       property string_value
@@ -10,7 +23,7 @@ module Neo4j
       property used
 
       def initialize
-        @type = :EOF
+        @type = Type::Eof
         @string_value = ""
         @int_value = 0_i8
         @float_value = 0.0_f64
@@ -25,16 +38,14 @@ module Neo4j
 
       def to_s(io)
         case @type
-        when :nil
-          io << :nil
-        when :STRING
+        when .string?
           @string_value.inspect(io)
-        when :INT
+        when .int?
           io << @int_value
-        when :FLOAT
+        when .float?
           io << @float_value
         else
-          io << @type
+          io << ":#{@type.to_s.upcase}"
         end
       end
     end

--- a/src/neo4j/pack_stream/unpacker.cr
+++ b/src/neo4j/pack_stream/unpacker.cr
@@ -24,13 +24,13 @@ module Neo4j
 
       def read_nil
         next_token
-        check :nil
+        check Token::Type::Null
         nil
       end
 
       def read_nil_or
         token = prefetch_token
-        if token.type == :nil
+        if token.type.null?
           token.used = true
           nil
         else
@@ -41,9 +41,9 @@ module Neo4j
       def read_bool
         next_token
         case token.type
-        when :true
+        when .true?
           true
-        when :false
+        when .false?
           false
         else
           unexpected_token
@@ -53,26 +53,26 @@ module Neo4j
       def read_numeric
         next_token
         case token.type
-        when :INT
+        when .int?
           token.int_value
-        when :FLOAT
+        when .float?
           token.float_value
         else
           unexpected_token
         end
       end
 
-      {% for type in %w(int uint float string binary) %}
-        def read_{{type.id}}                          # def read_int
-          next_token
-          check :{{type.id.upcase}}                   #   check :INT
-          token.{{type.id}}_value                     #   token.int_value
-        end                                           # end
+      {% for type in %w(Int Float String) %}
+        def read_{{type.id.downcase}}      # def read_int
+          next_token                       #   next_token
+          check Token::Type::{{type.id}}   #   check Token::Type::Int
+          token.{{type.id.downcase}}_value #   token.int_value
+        end                                # end
       {% end %}
 
       def read_array(fetch_next_token = true)
         next_token if fetch_next_token
-        check :ARRAY
+        check Token::Type::Array
         Array(Type).new(token.size.to_i32) do
           read_value
         end
@@ -80,7 +80,7 @@ module Neo4j
 
       def read_hash(read_key = true, fetch_next_token = true)
         next_token if fetch_next_token
-        check :HASH
+        check Token::Type::Hash
         token.size.times do
           if read_key
             key = read_value
@@ -93,7 +93,7 @@ module Neo4j
 
       def read_hash(fetch_next_token = true)
         next_token if fetch_next_token
-        check :HASH
+        check Token::Type::Hash
         hash = Hash(String, Type).new(initial_capacity: token.size.to_i32)
         token.size.times do
           key = read_string
@@ -105,7 +105,7 @@ module Neo4j
 
       def read_structure(fetch_next_token = true)
         next_token if fetch_next_token
-        check :STRUCTURE
+        check Token::Type::Structure
 
         structure_type = read_value
 
@@ -159,7 +159,7 @@ module Neo4j
       def read_structure(fetch_next_token = true)
         next_token if fetch_next_token
 
-        check :STRUCTURE
+        check Token::Type::Structure
         token.size.times { yield }
       end
 
@@ -167,23 +167,23 @@ module Neo4j
         next_token
 
         case token.type
-        when :INT
+        when .int?
           token.int_value
-        when :FLOAT
+        when .float?
           token.float_value
-        when :STRING
+        when .string?
           token.string_value
-        when :nil
+        when .null?
           nil
-        when :true
+        when .true?
           true
-        when :false
+        when .false?
           false
-        when :ARRAY
+        when .array?
           read_array fetch_next_token: false
-        when :HASH
+        when .hash?
           read_hash fetch_next_token: false
-        when :STRUCTURE
+        when .structure?
           read_structure fetch_next_token: false
         else
           unexpected_token token.type


### PR DESCRIPTION
Hello!

I saw your repo and noticed you were using either NamedTuples or Symbols for things that are enumerable.  Enums can be preferred due to the extra compile time checks that you can't get with the other 2 options.  So, I put together this PR to give it a try.  I also just wanted to play with Enums. :smile:

I'm ok if you don't want to merge it, as it can be a little wordier than the previous code.  I also noticed you said this was inspired by the MessagePack shard, and looking there they do the same thing.  I'm considering making the same/similar PR there.

2 things of note in this PR:
- `Nil` cannot be an Enum value because it will create the helper method .nil? which collides with the compiler method.  I looked at the Bolt Protocol documentation and they use the term Null, so I went with that for the Enum value
-  https://github.com/jgaskins/neo4j.cr/blob/0e18e903603242ec624a0e8a7b9e45fb2f2f556c/src/neo4j/pack_stream/unpacker.cr#L65 has extra types that don't have corresponding methods (particularly uint and binary), so I removed them.