### PR TITLE
Support Bolt v2

### DIFF
--- a/spec/neo4j/bolt/connection_spec.cr
+++ b/spec/neo4j/bolt/connection_spec.cr
@@ -166,6 +166,23 @@ module Neo4j
             end
           end
         end
+
+        async_it "deserializes values" do
+          pool.connection do |connection|
+            connection.execute(<<-CYPHER).first.tap do |(datetime, point2d, latlng, point3d)|
+              RETURN
+                datetime(),
+                point({ x: 1, y: 2 }),
+                point({ latitude: 39, longitude: -76 }),
+                point({ x: 1, y: 2, z: 3 })
+            CYPHER
+              datetime.should be_a Time
+              point2d.should eq Point2D.new(x: 1, y: 2)
+              point3d.should eq Point3D.new(x: 1, y: 2, z: 3)
+              latlng.should eq LatLng.new(latitude: 39, longitude: -76)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/neo4j/pack_stream/packer_spec.cr
+++ b/spec/neo4j/pack_stream/packer_spec.cr
@@ -1,0 +1,42 @@
+require "../../../src/neo4j/pack_stream/packer"
+require "../../../src/neo4j/type"
+
+module Neo4j
+  module PackStream
+    describe Packer do
+      {
+        Point2D.new(x: 1, y: 2),
+        Point3D.new(x: 1, y: 2, z: 3),
+        LatLng.new(latitude: 12.34, longitude: 56.78),
+        Node.new(
+          id: 123,
+          labels: ["Foo"],
+          properties: {
+            "foo" => "bar",
+            "answer" => 42,
+            "contrived" => true,
+          } of String => Type,
+        ),
+        Relationship.new(
+          id: 123,
+          start: 456,
+          end: 789,
+          type: "OMG_LOL",
+          properties: {
+            "one" => 1,
+          } of String => Type,
+        ),
+      }.each do |value|
+        it "serializes and deserializes #{value.class}" do
+          io = IO::Memory.new
+          packer = Packer.new(io)
+          unpacker = Unpacker.new(io)
+
+          packer.write value
+          io.rewind
+          unpacker.read_value.should eq value
+        end
+      end
+    end
+  end
+end

--- a/src/neo4j/bolt/connection.cr
+++ b/src/neo4j/bolt/connection.cr
@@ -11,7 +11,7 @@ module Neo4j
     class Connection
       GOGOBOLT = "\x60\x60\xB0\x17"
       SUPPORTED_VERSIONS = String.new(Bytes[
-        0, 0, 0, 1,
+        0, 0, 0, 2,
         0, 0, 0, 0,
         0, 0, 0, 0,
         0, 0, 0, 0,

--- a/src/neo4j/bolt/connection.cr
+++ b/src/neo4j/bolt/connection.cr
@@ -97,9 +97,10 @@ module Neo4j
       rescue RollbackException
         execute "ROLLBACK"
       rescue e : NestedTransactionError
-        # We don't want a NestedTransactionError to be picked up by the
+        # We don't want our NestedTransactionError to be picked up by the
         # catch-all rescue below, so we're explicitly capturing and re-raising
         # here to bypass it
+        reset
         raise e
       rescue e : QueryException
         ack_failure

--- a/src/neo4j/pack_stream/packer.cr
+++ b/src/neo4j/pack_stream/packer.cr
@@ -185,6 +185,13 @@ module Neo4j
         self
       end
 
+      def write(time : Time)
+        write_byte 0x64
+        write_value time.to_unix
+        write_value time.nanosecond
+        self
+      end
+
       def write(node : Node)
         write_byte(0x4E)
         write_value node.id

--- a/src/neo4j/pack_stream/unpacker.cr
+++ b/src/neo4j/pack_stream/unpacker.cr
@@ -20,6 +20,10 @@ module Neo4j
         localtime: 0x74,
         time: 0x54,
         duration: 0x45,
+
+        # Points
+        point2d: 0x58,
+        point3d: 0x59,
       }
 
       def initialize(string_or_io)
@@ -150,6 +154,22 @@ module Neo4j
           time = Time::UNIX_EPOCH + read_int.nanoseconds
           offset = read_int.to_i32
           (time - offset.seconds).in(Time::Location.fixed(offset))
+        when STRUCTURE_TYPES[:point2d]
+          type = read_int.to_i16
+          case type
+          when 7203
+            Point2D.new(type: type, x: read_float, y: read_float)
+          when 4326
+            LatLng.new(type: type, longitude: read_float, latitude: read_float)
+          end
+        when STRUCTURE_TYPES[:point3d]
+          Point3D.new(
+            type: read_int.to_i16,
+            x: read_float,
+            y: read_float,
+            z: read_float,
+          )
+
         # TODO: Figure out how to represent Time::Span and Time::MonthSpan in the same object
         # when STRUCTURE_TYPES[:duration]
         #   Time::Span.new(months: read_int, days: read_int, seconds: read_int, nanoseconds: read_int)

--- a/src/neo4j/type.cr
+++ b/src/neo4j/type.cr
@@ -95,6 +95,7 @@ module Neo4j
     Float64 |
     Array(Type) |
     Hash(String, Type) |
+    Time |
     Node |
     Relationship |
     UnboundRelationship |

--- a/src/neo4j/type.cr
+++ b/src/neo4j/type.cr
@@ -85,6 +85,29 @@ module Neo4j
   struct Ignored
   end
 
+  struct Point2D
+    getter x, y, type
+
+    def initialize(@x : Float64, @y : Float64, @type : Int16 = 7203_i16)
+    end
+  end
+
+  struct Point3D
+    getter x, y, z, type
+
+    def initialize(@x : Float64, @y : Float64, @z : Float64, @type : Int16 = 9157_i16)
+    end
+  end
+
+  struct LatLng
+    getter latitude : Float64
+    getter longitude : Float64
+    getter type : Int16
+
+    def initialize(@latitude : Float64, @longitude : Float64, @type = 4326_i16)
+    end
+  end
+
   alias Type = Nil |
     Bool |
     String |
@@ -96,6 +119,9 @@ module Neo4j
     Array(Type) |
     Hash(String, Type) |
     Time |
+    Point2D |
+    Point3D |
+    LatLng |
     Node |
     Relationship |
     UnboundRelationship |


### PR DESCRIPTION
Bolt v1 doesn't support date/time types, but Bolt v2 does. In the latest Neo4j, trying to serialize these types over Bolt v1 will tell you to upgrade Bolt. This is the result of a little reverse-engineering of those values.

The `Duration` type in Neo4j doesn't seem to map very well to Crystal. Crystal defines two separate types for this: `Time::Span` and `Time::MonthSpan`. We may need to build our own wrapper around both of them for now, but I'll also look into putting together an upstream PR into Crystal if I can figure out how to add support for months/years in `Time::Span`.

I'll add more data types as I find them.

Note: It's also possible that this is due to using the Enterprise edition of Neo4j in development. I need to look a bit more into the Community edition and see if/how it handles Bolt v2.