### PR TITLE
Add support for casting query results

### DIFF
--- a/spec/neo4j/bolt/connection_spec.cr
+++ b/spec/neo4j/bolt/connection_spec.cr
@@ -89,6 +89,15 @@ module Neo4j
           CYPHER
         end
 
+        it "handles sending and receiving large queries" do
+          big_array = (0..1_000_000).to_a
+          result = connection.exec_cast "RETURN $value",
+            { value: big_array },
+            {Array(Int32)}
+
+          result.first.first.should eq big_array
+        end
+
         it "handles exceptions" do
           begin
             connection.execute "omg lol"

--- a/spec/neo4j/mapping_spec.cr
+++ b/spec/neo4j/mapping_spec.cr
@@ -43,7 +43,7 @@ module Neo4j
   describe "mapping" do
     it "maps nodes to models" do
       model = MappingNodeExample.new(Node.new(
-        id: 123,
+        id: 123_i64,
         labels: ["Foo", "Bar"],
         properties: Map {
           "name" => "Jamie",
@@ -77,9 +77,9 @@ module Neo4j
 
     it "maps relationships to models" do
       model = MappingRelationshipExample.new(Relationship.new(
-        id: 123,
-        start: 456,
-        end: 789,
+        id: 123_i64,
+        start: 456_i64,
+        end: 789_i64,
         type: "FOO_BAR",
         properties: Map {
           "role" => "user",

--- a/spec/neo4j/pack_stream/lexer_spec.cr
+++ b/spec/neo4j/pack_stream/lexer_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Neo4j
   module PackStream

--- a/spec/neo4j/pack_stream/packer_spec.cr
+++ b/spec/neo4j/pack_stream/packer_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 require "../../../src/neo4j/pack_stream"
 require "../../../src/neo4j/type"

--- a/spec/neo4j/pack_stream/packer_spec.cr
+++ b/spec/neo4j/pack_stream/packer_spec.cr
@@ -84,20 +84,20 @@ module Neo4j
         Node.new(
           id: 123,
           labels: ["Foo"],
-          properties: {
+          properties: Map {
             "foo" => "bar",
             "answer" => 42,
             "contrived" => true,
-          } of String => Type,
+          },
         ),
         Relationship.new(
           id: 123,
           start: 456,
           end: 789,
           type: "OMG_LOL",
-          properties: {
+          properties: Map {
             "one" => 1,
-          } of String => Type,
+          },
         ),
       }.each do |value|
         it "serializes and deserializes #{value.class}" do

--- a/spec/neo4j/pack_stream/packer_spec.cr
+++ b/spec/neo4j/pack_stream/packer_spec.cr
@@ -82,7 +82,7 @@ module Neo4j
           location: ::Time::Location.load("America/New_York"),
         ),
         Node.new(
-          id: 123,
+          id: 123_i64,
           labels: ["Foo"],
           properties: Map {
             "foo" => "bar",
@@ -91,9 +91,9 @@ module Neo4j
           },
         ),
         Relationship.new(
-          id: 123,
-          start: 456,
-          end: 789,
+          id: 123_i64,
+          start: 456_i64,
+          end: 789_i64,
           type: "OMG_LOL",
           properties: Map {
             "one" => 1,

--- a/spec/neo4j/pack_stream/unpacker_spec.cr
+++ b/spec/neo4j/pack_stream/unpacker_spec.cr
@@ -1,6 +1,6 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
-require "../../../../src/neo4j/pack_stream"
+require "../../../src/neo4j/pack_stream"
 
 module Neo4j
   module PackStream

--- a/src/neo4j/bolt/connection.cr
+++ b/src/neo4j/bolt/connection.cr
@@ -103,7 +103,15 @@ module Neo4j
         end
       end
 
-      def exec_cast(query : String, parameters : Map, types : TYPES) forall TYPES
+      def exec_cast(query : String, types : Tuple(*TYPES)) forall TYPES
+        exec_cast query, Map.new, types
+      end
+
+      def exec_cast(query : String, parameters : NamedTuple, types : Tuple(*TYPES)) forall TYPES
+        exec_cast query, parameters.to_h.transform_keys(&.to_s), types
+      end
+
+      def exec_cast(query : String, parameters : Map, types : Tuple(*TYPES)) forall TYPES
         run query, parameters
 
         write_message do |msg|

--- a/src/neo4j/bolt/from_bolt.cr
+++ b/src/neo4j/bolt/from_bolt.cr
@@ -1,3 +1,5 @@
+require "uuid"
+
 require "../pack_stream/token"
 require "../pack_stream/unpacker"
 require "../exceptions"

--- a/src/neo4j/bolt/from_bolt.cr
+++ b/src/neo4j/bolt/from_bolt.cr
@@ -1,0 +1,31 @@
+{% for size in %w(8 16 32 64) %}
+  def Int{{size.id}}.from_bolt(io)
+    Neo4j::PackStream::Unpacker.new(io).read_int.to_i{{size.id}}
+  end
+{% end %}
+
+def Float64.from_bolt(io)
+  Neo4j::PackStream::Unpacker.new(io).read_float
+end
+
+def String.from_bolt(io)
+  Neo4j::PackStream::Unpacker.new(io).read_string
+end
+
+def Bool.from_bolt(io)
+  Neo4j::PackStream::Unpacker.new(io).read_bool
+end
+
+module Neo4j
+  def Point2D.from_bolt(io)
+    PackStream::Unpacker.new(io).read_structure.as(Point2D)
+  end
+
+  def LatLng.from_bolt(io)
+    PackStream::Unpacker.new(io).read_structure.as(LatLng)
+  end
+
+  def Point3D.from_bolt(io)
+    PackStream::Unpacker.new(io).read_structure.as(Point3D)
+  end
+end

--- a/src/neo4j/bolt/from_bolt.cr
+++ b/src/neo4j/bolt/from_bolt.cr
@@ -1,3 +1,6 @@
+require "../pack_stream/token"
+require "../pack_stream/unpacker"
+
 {% for size in %w(8 16 32 64) %}
   def Int{{size.id}}.from_bolt(io)
     Neo4j::PackStream::Unpacker.new(io).read_int.to_i{{size.id}}
@@ -14,6 +17,14 @@ end
 
 def Bool.from_bolt(io)
   Neo4j::PackStream::Unpacker.new(io).read_bool
+end
+
+def Array.from_bolt(io)
+  unpacker = Neo4j::PackStream::Unpacker.new(io)
+
+  token = unpacker.next_token
+  unpacker.check Neo4j::PackStream::Token::Type::Array
+  new(token.size.to_i32) { T.from_bolt(io) }
 end
 
 module Neo4j

--- a/src/neo4j/bolt/transaction.cr
+++ b/src/neo4j/bolt/transaction.cr
@@ -5,15 +5,9 @@ module Neo4j
     struct Transaction
       getter connection
 
+      delegate execute, stream, exec_cast, to: connection
+
       def initialize(@connection : Neo4j::Bolt::Connection)
-      end
-
-      def execute(_query, **parameters)
-        connection.execute _query, **parameters
-      end
-
-      def execute(query, parameters : Hash(String, Type))
-        connection.execute query, parameters
       end
 
       def rollback

--- a/src/neo4j/exceptions.cr
+++ b/src/neo4j/exceptions.cr
@@ -3,8 +3,9 @@ module Neo4j
   end
 
   class UnknownResult < Exception
-    def initialize(@message)
-    end
+  end
+
+  class UnknownType < Exception
   end
 
   class QueryException < Exception

--- a/src/neo4j/mapping.cr
+++ b/src/neo4j/mapping.cr
@@ -34,9 +34,9 @@ module Neo4j
   end
 
   macro map_relationship(__properties__)
-    getter relationship_id : Int32
-    getter node_start : Int32
-    getter node_end : Int32
+    getter relationship_id : Int64
+    getter node_start : Int64
+    getter node_end : Int64
     getter relationship_type : String
 
     ::Neo4j.map_props({{__properties__}}, ::Neo4j::Relationship)
@@ -47,7 +47,7 @@ module Neo4j
   end
 
   macro map_node(__properties__)
-    getter node_id : Int32
+    getter node_id : Int64
     getter node_labels : Array(String)
 
     ::Neo4j.map_props({{__properties__}}, ::Neo4j::Node)

--- a/src/neo4j/mapping.cr
+++ b/src/neo4j/mapping.cr
@@ -95,6 +95,10 @@ module Neo4j
       {% end %}
     {% end %}
 
+    def self.from_bolt(io)
+      new ::Neo4j::PackStream::Unpacker.new(io).read_structure(io).as(::Neo4j::Node)
+    end
+
     def initialize(%node : {{type}})
       {% if type.resolve == ::Neo4j::Node %}
         @node_id = %node.id

--- a/src/neo4j/pack_stream/token.cr
+++ b/src/neo4j/pack_stream/token.cr
@@ -19,7 +19,7 @@ module Neo4j
       property string_value
       property int_value : Int8 | Int16 | Int32 | Int64
       property float_value : Float64
-      property size : UInt16
+      property size : UInt64
       property used
 
       def initialize
@@ -33,7 +33,7 @@ module Neo4j
       end
 
       def size=(size)
-        @size = size.to_u16
+        @size = size.to_u64
       end
 
       def to_s(io)

--- a/src/neo4j/pack_stream/unpacker.cr
+++ b/src/neo4j/pack_stream/unpacker.cr
@@ -216,10 +216,10 @@ module Neo4j
       end
 
       private delegate token, to: @lexer
-      private delegate next_token, to: @lexer
+      delegate next_token, to: @lexer
       delegate prefetch_token, to: @lexer
 
-      private def check(token_type)
+      def check(token_type)
         unexpected_token(token_type) unless token.type == token_type
       end
 

--- a/src/neo4j/pack_stream/unpacker.cr
+++ b/src/neo4j/pack_stream/unpacker.cr
@@ -101,35 +101,30 @@ module Neo4j
 
         case structure_type
         when StructureTypes::Node.value
-          id = read_numeric.to_i32
-          labels = read_array.map(&.to_s)
-          props = read_hash
-            .each_with_object(Map.new) { |(k, v), h|
-              h[k.to_s] = v }
-          Node.new(id, labels, props)
+          Node.new(
+            id: read_numeric.to_i64,
+            labels: read_array.map(&.as(String)),
+            properties: read_hash.transform_keys(&.to_s),
+          )
         when StructureTypes::Relationship.value
           Relationship.new(
-            id: read_numeric.to_i32,
-            start: read_numeric.to_i32,
-            end: read_numeric.to_i32,
+            id: read_numeric.to_i64,
+            start: read_numeric.to_i64,
+            end: read_numeric.to_i64,
             type: read_string,
-            properties: read_hash
-              .each_with_object(Map.new) { |(k, v), h|
-                h[k.to_s] = v }
+            properties: read_hash.transform_keys(&.to_s),
           )
         when StructureTypes::Path.value
           Path.new(
-            nodes: read_array.map { |node| node.as(Node) },
+            nodes: read_array.map(&.as(Node)),
             relationships: read_array.map(&.as(UnboundRelationship)),
             sequence: read_array.map(&.as(Int8)),
           )
         when StructureTypes::UnboundRelationship.value
           UnboundRelationship.new(
-            id: read_numeric.to_i32,
+            id: read_numeric.to_i64,
             type: read_string,
-            properties: read_hash
-              .each_with_object(Map.new) { |(k, v), h|
-                h[k.to_s] = v }
+            properties: read_hash.transform_keys(&.to_s),
           )
         when StructureTypes::Success.value
           Success.new(read_hash)

--- a/src/neo4j/pack_stream/unpacker.cr
+++ b/src/neo4j/pack_stream/unpacker.cr
@@ -215,7 +215,7 @@ module Neo4j
         end
       end
 
-      private delegate token, to: @lexer
+      delegate token, to: @lexer
       delegate next_token, to: @lexer
       delegate prefetch_token, to: @lexer
 

--- a/src/neo4j/type.cr
+++ b/src/neo4j/type.cr
@@ -1,7 +1,7 @@
 module Neo4j
   struct Node
     getter(
-      id : Int32,
+      id : Int64,
       labels : Array(String),
       properties : Map,
     )
@@ -12,9 +12,9 @@ module Neo4j
 
   struct Relationship
     getter(
-      id : Int32,
-      start : Int32,
-      end : Int32,
+      id : Int64,
+      start : Int64,
+      end : Int64,
       type : String,
       properties : Map,
     )
@@ -25,7 +25,7 @@ module Neo4j
 
   struct UnboundRelationship
     getter(
-      id : Int32,
+      id : Int64,
       type : String,
       properties : Map,
     )


### PR DESCRIPTION
Given a mapping from a `Neo4j::Node` to a domain object:

```crystal
struct User
  Neo4j.map_node(
    id: UUID,
    name: String,
    # ...
  )
end
```

Currently, calling `execute` or `stream` on a connection gives you a 2-dimensional list of [`Neo4j::ValueType`](https://github.com/jgaskins/neo4j.cr/blob/master/src/neo4j/type.cr#L104-L122) — one dimension for each value in the `RETURN` clause, and the other dimension for each result in the set.

Unfortunately, this requires someone using the driver to cast the `RETURN` values themselves. I end up doing this a lot:

```crystal
def find_user(email : String) : User?
  result = connection.execute(<<-CYPHER, email: email)
    MATCH (user:User { email: $email })
    RETURN user
    LIMIT 1
  CYPHER

  if result.any?
    User.new(result.first.first.as(Neo4j::Node))
  end
end
```

This PR allows you to pass the types into the call for the query into the `exec_cast` method, skipping the typecasting to `Neo4j::Node` and then wrapping that node in a `User.new` call:

```crystal
def find_user(email : String) : User?
  # I have no idea what to call this method, but it's basically `execute` with type casting,
  # so it's working name is `exec_cast`
  result = connection.exec_cast(<<-CYPHER, Neo4j::Map { "email" => email }, { User })
    MATCH (user:User { email: $email })
    RETURN user
    LIMIT 1
  CYPHER

  result.first.first if result.any?
end
```

The main difference is that it removes the need for `.as(Neo4j::Node)` and the explicit conversion to a `User` in application code. Any type that responds to `self.from_bolt(io)` should be able to work here. This implementation with `Neo4j.map_node` still builds the `Node` (including the properties hash), but I'd like to make this more efficient by avoiding those heap allocations and deserialize directly to the mapped node. This might require duplicating some functionality of `Neo4j::PackStream::Unpacker` or maybe we could copy the idea from `JSON.mapping` where it works with the `JSON::PullParser`, but this will require exposing more functionality of `Unpacker`.

Also, I'd like to be able to use union types somehow. For example, you may need to use `Type?` with an `OPTIONAL MATCH` clause or a node might be connected to two different types of nodes, necessitating a `This | That` type. `JSON.mapping` defines [`Union.new(pull : JSON::PullParser)`](https://github.com/crystal-lang/crystal/blob/60760a5460aa13a1f80c5a1a7410782dc4076b77/src/json/from_json.cr#L188-L227) to make that work, so we might be able to piggyback on that idea.